### PR TITLE
gen_domain: Adding user name from command line input

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ After the compilation you can execute `gen_domain` with $MAPFILE being one of th
 The choice of $MAPFILE does not influence the lat- and longitude values in the domain file but can influence the land/sea mask.
 
 ```
-./gen_domain -m $MAPFILE -o $GRIDNAME -l $GRIDNAME
+./gen_domain -m $MAPFILE -o $GRIDNAME -l $GRIDNAME -u $USER
 ```
 
 The created domain file will later be modified.


### PR DESCRIPTION
Added the command line input `-u` that fills the `user` variable. The `user` variable is used to set the attribute `history` of the domain file.

---

**Motivation**: The variable `user` was unset. Setting the variable  `user `from environment variables is commented out:

https://github.com/HPSCTerrSys/eCLM_static-file-generator/blob/6c83cff762bbd94b896d188b4b7c5645bc64d47c/gen_domain_files/src/gen_domain.F90#L611-L617

This led to a non-human-readable string in the `history` attribute of the domain file.

