### PR TITLE
mkmapdata: Open up conservative remapping to general GRIDNAME

### DIFF
--- a/mkmapdata/runscript_mkmapdata.sh
+++ b/mkmapdata/runscript_mkmapdata.sh
@@ -44,10 +44,6 @@ do
         echo "Creating conservative remapping files for your grid ${GRIDNAME}..."
         srun $ESMFBIN_PATH/ESMF_RegridWeightGen --ignore_unmapped -s ${rawpath}/${file} -d $GRIDFILE -m conserve -w ${OUTPUT}/${OUTFILE} --dst_regional --netcdf4
         ;;
-      # *)
-      #   echo "Invalid GRIDNAME specified (${GRIDNAME}).  It should start with 'EUR-'."
-      #   exit 1
-      #   ;;
     esac
 done
 


### PR DESCRIPTION
Currently, any `GRIDNAME` that does not contain `EUR` leads to an error, but as far as I understand, this does not have to be the case!