### PR TITLE
Absolute paths into NetCDF attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,10 @@ gfortran -o gen_domain src/gen_domain.F90 -mkl -I${INC_NETCDF} -lnetcdff -lnetcd
 After the compilation you can execute `gen_domain` with $MAPFILE being one of the mapping files created in the step before (in `mkmapdata/`) and $GRIDNAME being a string with the name of your grid, e.g. `EUR-R13B05` for the ~12-km icosahedral grid.
 The choice of $MAPFILE does not influence the lat- and longitude values in the domain file but can influence the land/sea mask.
 
+**Hint:** For better reproducibility, specify the absolute path of
+`$MAPFILE`. The absolute path to the file can be printed using
+`realpath $MAPFILE`.
+
 ```
 ./gen_domain -m $MAPFILE -o $GRIDNAME -l $GRIDNAME -u $USER
 ```

--- a/mkmapdata/runscript_mkmapdata.sh
+++ b/mkmapdata/runscript_mkmapdata.sh
@@ -38,11 +38,11 @@ do
     case "$GRIDNAME" in
       *"EUR-R13B"*)
         echo "Creating non-conservative remapping files for your icosahedral grid ${GRIDNAME}..."
-        srun $ESMFBIN_PATH/ESMF_RegridWeightGen --ignore_unmapped -s ${rawpath}/${file} -d $GRIDFILE -m bilinear --src_loc center --dst_loc center -w ${OUTPUT}/${OUTFILE} --dst_regional --netcdf4
+        srun $ESMFBIN_PATH/ESMF_RegridWeightGen --ignore_unmapped -s ${rawpath}/${file} -d $(realpath $GRIDFILE) -m bilinear --src_loc center --dst_loc center -w ${OUTPUT}/${OUTFILE} --dst_regional --netcdf4
         ;;
       *)
         echo "Creating conservative remapping files for your grid ${GRIDNAME}..."
-        srun $ESMFBIN_PATH/ESMF_RegridWeightGen --ignore_unmapped -s ${rawpath}/${file} -d $GRIDFILE -m conserve -w ${OUTPUT}/${OUTFILE} --dst_regional --netcdf4
+        srun $ESMFBIN_PATH/ESMF_RegridWeightGen --ignore_unmapped -s ${rawpath}/${file} -d $(realpath $GRIDFILE) -m conserve -w ${OUTPUT}/${OUTFILE} --dst_regional --netcdf4
         ;;
     esac
 done


### PR DESCRIPTION
While trying to reproduce existing files, I noticed that there were many relative paths in my NetCDF attributes, e.g. in the domain file:
```
                :map_grid_file_atm = "../mkmapgrids/SCRIPgrid_DE-RuS_nomask_c250926.nc" ;
```

Here are changes from my side going in the direction of forcing absolute paths.

Wanted you to have a look at it before moving it into the `dev-atmforcing`, @mvhulten 